### PR TITLE
Add pnpm-workspace.yaml to approve dependency build scripts

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+allowBuilds:
+  esbuild: true
+  pi-decimals: true


### PR DESCRIPTION
## Summary

pnpm 11 blocks dependency install/build lifecycle scripts by default as a supply-chain safeguard. Two dependencies legitimately need theirs:

- **esbuild** — its `postinstall` downloads/links the platform-specific native binary
- **pi-decimals** — its `install` script generates required data files

Without approval, `pnpm install` exits with code 1 (`ERR_PNPM_IGNORED_BUILDS`), and since pnpm 11 verifies dependencies before running a script, `pnpm dev` fails to start on a fresh clone.

## Change

Adds `pnpm-workspace.yaml` approving both packages via `allowBuilds`, so install completes cleanly and `pnpm dev` boots.

## Testing

- `pnpm install` → exits 0, both build scripts run
- `pnpm dev` → Next.js dev server ready on http://localhost:3000