### PR TITLE
Add status filter and highlight failed runs on dashboard

### DIFF
--- a/components/StatsDashboard.tsx
+++ b/components/StatsDashboard.tsx
@@ -2,17 +2,7 @@ import React from 'react'
 import { Cell, Pie, PieChart, ResponsiveContainer, Tooltip } from 'recharts'
 import { ActionJobResult, WorkflowRunStatus } from '../src/api/generated'
 import { Surface, SectionTitle } from './Surface'
-
-/** Format a duration in seconds into a compact human string. */
-function formatDuration(seconds: number): string {
-    if (!isFinite(seconds) || seconds <= 0) return '—'
-    if (seconds < 60) return `${Math.round(seconds)}s`
-    const mins = seconds / 60
-    if (mins < 60) return `${mins.toFixed(1)}m`
-    const hrs = Math.floor(mins / 60)
-    const rem = Math.round(mins % 60)
-    return `${hrs}h ${rem}m`
-}
+import { formatDuration } from '../utils/format'
 
 interface DashboardStats {
     total: number

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -12,10 +12,19 @@ import { Surface, SectionTitle } from '../components/Surface'
 import { BrandSelect } from '../components/Inputs'
 import { Pager } from '../components/Pager'
 import analytic from '../global/mixpanel'
-import { useGetBranch, useGetGitcommit } from '../src/api/generated'
+import { useGetBranch, useGetGitcommit, WorkflowRunStatus } from '../src/api/generated'
+import { formatDuration } from '../utils/format'
 import { StatusToColor, StatusToHumanText } from './workflow/[id]'
 
 const DEFAULT_REPO = 'comfyanonymous/ComfyUI'
+
+// Status filter options. The /gitcommit API has no status param, so this filters
+// the rows already loaded for the current page (see note rendered below the table).
+const STATUS_OPTIONS: { label: string; value: string }[] = [
+    { label: 'Failed', value: WorkflowRunStatus.WorkflowRunStatusFailed },
+    { label: 'In Progress', value: WorkflowRunStatus.WorkflowRunStatusStarted },
+    { label: 'Success', value: WorkflowRunStatus.WorkflowRunStatusCompleted },
+]
 
 function GitCommitsList() {
     const [currentPage, setCurrentPage] = React.useState(1)
@@ -26,6 +35,8 @@ function GitCommitsList() {
     const [branchFilter, setBranchFilter] = React.useState<string>('Select Branch')
     const [commitId, setCommitId] = React.useState<string>('')
     const [workflowNameFilter, setWorkflowFilter] = React.useState<string>('')
+    // Client-side only (the API has no status param) — not synced to the URL.
+    const [statusFilter, setStatusFilter] = React.useState<string>('')
 
     const prevFilters = React.useRef({ filterOS, repoFilter, branchFilter, commitId, workflowNameFilter, currentPage });
 
@@ -56,7 +67,6 @@ function GitCommitsList() {
                 workflowName: workflowNameFilter || undefined,
                 page: currentPage.toString(),
             };
-            console.log(`Updating url parameters due to filter change, ${JSON.stringify(query)} vs ${JSON.stringify(prevFilters.current)}`)
             router.push({ pathname: router.pathname, query }, undefined, { shallow: true });
 
             // Update the ref with the new values
@@ -88,17 +98,22 @@ function GitCommitsList() {
     }, [router.query.repo]);
 
     const jobResults = filteredJobResults?.jobResults ?? []
+    const visibleResults = statusFilter
+        ? jobResults.filter((r) => r.status === statusFilter)
+        : jobResults
     const hasActiveFilters =
         filterOS !== 'Select OS' ||
         branchFilter !== 'Select Branch' ||
         commitId !== '' ||
-        workflowNameFilter !== ''
+        workflowNameFilter !== '' ||
+        statusFilter !== ''
 
     const clearAll = () => {
         setFilterOS('Select OS')
         setBranchFilter('Select Branch')
         setCommitId('')
         setWorkflowFilter('')
+        setStatusFilter('')
         setCurrentPage(1)
     }
 
@@ -170,6 +185,22 @@ function GitCommitsList() {
                         <option value="macos">macos</option>
                         <option value="windows">windows</option>
                     </BrandSelect>
+                    <BrandSelect
+                        id="status-select"
+                        value={statusFilter}
+                        onChange={(e) => {
+                            setStatusFilter(e.target.value)
+                            analytic.track('Change Status Filter', { status: e.target.value })
+                        }}
+                        className="w-44"
+                    >
+                        <option value="">Select Status</option>
+                        {STATUS_OPTIONS.map((s) => (
+                            <option key={s.value} value={s.value}>
+                                {s.label}
+                            </option>
+                        ))}
+                    </BrandSelect>
                     <ClearableLabel
                         id="commit-id-input"
                         label="Commit ID"
@@ -206,6 +237,12 @@ function GitCommitsList() {
                 </Surface>
             ) : (
                 <>
+                    {statusFilter && (
+                        <p className="mb-2 text-xs text-ash-500 dark:text-smoke-800">
+                            Showing {visibleResults.length} of {jobResults.length} run{jobResults.length === 1 ? '' : 's'} on this page matching{' '}
+                            <span className="font-semibold">{StatusToHumanText(statusFilter as WorkflowRunStatus)}</span>.
+                        </p>
+                    )}
                     <Surface className="overflow-hidden">
                         <div className="overflow-x-auto scrollbar-thin">
                             <table className="w-full text-left text-sm">
@@ -221,10 +258,20 @@ function GitCommitsList() {
                                     </tr>
                                 </thead>
                                 <tbody className="divide-y divide-smoke-200 dark:divide-charcoal-400/40">
-                                    {jobResults.map((result, index) => (
+                                    {visibleResults.length === 0 && (
+                                        <tr>
+                                            <td colSpan={7} className="px-5 py-10 text-center text-sm text-ash-500 dark:text-smoke-800">
+                                                No runs match the selected status on this page.
+                                            </td>
+                                        </tr>
+                                    )}
+                                    {visibleResults.map((result, index) => (
                                         <tr
-                                            key={index}
-                                            className="group transition-colors hover:bg-smoke-200/60 dark:hover:bg-charcoal-700/40"
+                                            key={result.id || index}
+                                            className={`group transition-colors hover:bg-smoke-200/60 dark:hover:bg-charcoal-700/40 ${result.status === WorkflowRunStatus.WorkflowRunStatusFailed
+                                                ? 'bg-red-500/[0.06] dark:bg-red-500/[0.08]'
+                                                : ''
+                                                }`}
                                         >
                                             {/* Workflow */}
                                             <td className="px-5 py-4 align-top">
@@ -339,7 +386,7 @@ function GitCommitsList() {
                                             <td className="px-5 py-4 align-top">
                                                 <span className="font-mono text-sm tabular-nums">
                                                     {result.end_time && result.start_time
-                                                        ? calculateTimeDifference(result.end_time, result.start_time)
+                                                        ? formatDuration(Math.abs(result.end_time - result.start_time))
                                                         : 'unknown'}
                                                 </span>
                                             </td>
@@ -374,17 +421,6 @@ function GitCommitsList() {
             )}
         </div>
     );
-}
-
-export function calculateTimeDifference(startTime: number, endTime: number): string {
-    const differenceInSeconds = Math.abs(endTime - startTime)
-    const difference =
-        differenceInSeconds >= 60
-            ? parseFloat((differenceInSeconds / 60).toFixed(1))
-            : differenceInSeconds
-    return differenceInSeconds >= 60
-        ? `${difference} minute`
-        : `${difference} sec`
 }
 
 export default GitCommitsList

--- a/pages/workflow/[id].tsx
+++ b/pages/workflow/[id].tsx
@@ -10,7 +10,7 @@ import { WorkflowStatusButton } from "../../components/StatusButton";
 import { Surface, SectionTitle } from "../../components/Surface";
 import UsageGraph from "../../components/UsageGraph";
 import LongTextPreview from "../../components/LongTextPreview";
-import { calculateTimeDifference } from "..";
+import { formatDuration } from "../../utils/format";
 
 const Row: React.FC<React.PropsWithChildren<{ label: string }>> = ({ label, children }) => (
     <div className="flex flex-col gap-1 border-b border-smoke-200 dark:border-charcoal-400/40 py-3 sm:flex-row sm:items-start sm:gap-4 last:border-0">
@@ -96,7 +96,7 @@ function WorkflowResultDetail() {
                             </span>
                             <span className="font-mono text-sm tabular-nums text-charcoal-800 dark:text-smoke-200">
                                 {workflowResult.end_time && workflowResult.start_time
-                                    ? calculateTimeDifference(workflowResult.end_time, workflowResult.start_time)
+                                    ? formatDuration(Math.abs(workflowResult.end_time - workflowResult.start_time))
                                     : 'unknown'}
                             </span>
                         </div>
@@ -150,7 +150,7 @@ function WorkflowResultDetail() {
                     <Row label="Triggered By">{workflowResult?.job_trigger_user}</Row>
                     <Row label="Run Time">
                         {workflowResult.end_time && workflowResult.start_time
-                            ? calculateTimeDifference(workflowResult.end_time, workflowResult.start_time)
+                            ? formatDuration(Math.abs(workflowResult.end_time - workflowResult.start_time))
                             : "unknown"}
                     </Row>
                     <Row label="Versions">

--- a/utils/format.ts
+++ b/utils/format.ts
@@ -1,0 +1,10 @@
+/** Format a duration in seconds into a compact human string (e.g. "45s", "1.5m", "1h 3m"). */
+export function formatDuration(seconds: number): string {
+    if (!isFinite(seconds) || seconds <= 0) return '—'
+    if (seconds < 60) return `${Math.round(seconds)}s`
+    const mins = seconds / 60
+    if (mins < 60) return `${mins.toFixed(1)}m`
+    const hrs = Math.floor(mins / 60)
+    const rem = Math.round(mins % 60)
+    return `${hrs}h ${rem}m`
+}


### PR DESCRIPTION
Since CI failures currently have no notifications, the dashboard is the only place anyone sees them — so this makes failures easier to spot, plus some cleanup.

## Changes
- **Status filter** (Failed / In Progress / Success) on the Workflow Results table. The `/gitcommit` API has no status parameter, so this filters the rows already loaded for the current page, client-side. A caption under the filters states the scope ("Showing N of M runs on this page matching …") so it's not mistaken for a global filter.
- **Failed rows are tinted red** for at-a-glance scanning.
- **Stable React keys** (result id) instead of array index in the results table.
- **One shared `formatDuration`** (`utils/format.ts`) replacing three diverging formatters — the old `calculateTimeDifference` rendered e.g. `1.5 minute` / `30 sec` while the stats card rendered `1.5m` / `45s`. Now consistent everywhere (workflow table, workflow detail, stats).
- Removed a stray `console.log` left in the filter effect.

## Verification
`pnpm build` and `pnpm lint` both pass. Changes are presentational + client-side filtering; no API or data-model changes.

## Follow-ups (backend-gated, not in this PR)
- A real **status filter** and **global success-rate** need a server-side param / aggregate endpoint on `api.comfy.org` — the current stats cards are necessarily scoped to the loaded page ("in current view"). Worth a backend ticket.